### PR TITLE
Use Rapid YAML from PyPi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 psutil
 ninja
-git+https://github.com/litghost/rapidyaml.git@fixup_python_packaging#egg=rapidyaml
+rapidyaml
 fasm
 git+https://github.com/SymbiFlow/prjxray.git
 git+https://github.com/SymbiFlow/symbiflow-xc-fasm.git


### PR DESCRIPTION
Use RapidYAML from PyPi since it was released almost one year ago.
Adresses [this](https://github.com/chipsalliance/python-fpga-interchange/issues/11) issue.
BTW update the RW submodule.