### PR TITLE
Feature tests for Ultrascale+ (hanging on analytical placer)

### DIFF
--- a/tests/features/dram/CMakeLists.txt
+++ b/tests/features/dram/CMakeLists.txt
@@ -6,6 +6,15 @@ function(dram_tests dram_num_instances dram_mode)
     )
 endfunction()
 
+function(dram_tests_diff dram_num_instances dram_mode)
+    add_generic_test(
+        name dram_${dram_num_instances}_${dram_mode}_diff
+        board_list zcu104
+        sources dram_${dram_num_instances}_${dram_mode}_diff.v
+        top top_diff
+    )
+endfunction()
+
 # dram_tests(<dram_num_instances> <dram_mode>)
 dram_tests(4 32x1s)
 dram_tests(8 32x1s)
@@ -18,3 +27,6 @@ dram_tests(1 128x1d)
 dram_tests(1 256x1s)
 dram_tests(1 32m)
 dram_tests(1 64m)
+
+# FIXME: Timeout on analytical placer
+dram_tests_diff(1 256x1s)

--- a/tests/features/dram/dram_1_256x1s_diff.v
+++ b/tests/features/dram/dram_1_256x1s_diff.v
@@ -1,0 +1,21 @@
+`include "dram_1_256x1s.v"
+
+module top_diff (
+    input wire clk_p,
+    input wire clk_n,
+    input wire rx,
+    output wire tx,
+    input wire [15:0] sw,
+    output wire [15:0] led
+);
+    wire clk;
+    IBUFDS ibuf_ds (.I(clk_p), .IB(clk_n), .O(clk));
+    top top_ (
+        .rx(rx),
+        .tx(tx),
+        .sw(sw),
+        .led(led),
+        .clk(clk)
+    );
+endmodule
+

--- a/tests/features/dram/dram_1_256x1s_diff.v
+++ b/tests/features/dram/dram_1_256x1s_diff.v
@@ -1,3 +1,11 @@
+// Copyright (C) 2021  The Symbiflow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
 `include "dram_1_256x1s.v"
 
 module top_diff (

--- a/tests/features/dram/zcu104.xdc
+++ b/tests/features/dram/zcu104.xdc
@@ -1,0 +1,90 @@
+# ZCU-104 board
+
+# Clock
+set_property PACKAGE_PIN H11 [get_ports clk_p]
+set_property PACKAGE_PIN G11 [get_ports clk_n]
+
+set_property IOSTANDARD LVDS [get_ports clk_p]
+set_property IOSTANDARD LVDS [get_ports clk_n]
+
+# PMOD GPIO
+set_property PACKAGE_PIN  G8 [get_ports led[0]]
+set_property PACKAGE_PIN  H8 [get_ports led[1]]
+set_property PACKAGE_PIN  G7 [get_ports led[2]]
+set_property PACKAGE_PIN  H7 [get_ports led[3]]
+set_property PACKAGE_PIN  G6 [get_ports led[4]]
+set_property PACKAGE_PIN  H6 [get_ports led[5]]
+set_property PACKAGE_PIN  J6 [get_ports led[6]]
+set_property PACKAGE_PIN  J7 [get_ports led[7]]
+set_property PACKAGE_PIN  J9 [get_ports led[8]]
+set_property PACKAGE_PIN  K9 [get_ports led[9]]
+set_property PACKAGE_PIN  K8 [get_ports led[10]]
+set_property PACKAGE_PIN  L8 [get_ports led[11]]
+set_property PACKAGE_PIN L10 [get_ports led[12]]
+set_property PACKAGE_PIN M10 [get_ports led[13]]
+set_property PACKAGE_PIN  M8 [get_ports led[14]]
+set_property PACKAGE_PIN  M9 [get_ports led[15]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[3]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[4]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[5]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[6]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[7]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[8]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[9]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[10]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[11]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[12]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[13]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[14]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[15]]
+
+# Pushbuttons
+set_property PACKAGE_PIN B4 [get_ports sw[0]]
+set_property PACKAGE_PIN C4 [get_ports sw[1]]
+set_property PACKAGE_PIN B3 [get_ports sw[2]]
+set_property PACKAGE_PIN C3 [get_ports sw[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports sw[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[3]]
+
+# DIP SW
+
+set_property PACKAGE_PIN E4 [get_ports sw[4]]
+set_property PACKAGE_PIN D4 [get_ports sw[5]]
+set_property PACKAGE_PIN F5 [get_ports sw[6]]
+set_property PACKAGE_PIN F4 [get_ports sw[7]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports sw[4]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[5]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[6]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[7]]
+
+# Abusing HDMI pins
+
+set_property PACKAGE_PIN  B1 [get_ports sw[8]]
+set_property PACKAGE_PIN  C1 [get_ports sw[9]]
+set_property PACKAGE_PIN  A2 [get_ports sw[10]]
+set_property PACKAGE_PIN  A3 [get_ports sw[11]]
+set_property PACKAGE_PIN  E3 [get_ports sw[12]]
+set_property PACKAGE_PIN N11 [get_ports sw[13]]
+set_property PACKAGE_PIN M12 [get_ports sw[14]]
+set_property PACKAGE_PIN  F6 [get_ports sw[15]]
+set_property PACKAGE_PIN  E5 [get_ports rx]
+set_property PACKAGE_PIN  D1 [get_ports tx]
+
+set_property IOSTANDARD LVCMOS33 [get_ports sw[8]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[9]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[10]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[11]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[12]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[13]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[14]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[15]]
+set_property IOSTANDARD LVCMOS33 [get_ports rx]
+set_property IOSTANDARD LVCMOS33 [get_ports tx]

--- a/tests/features/pll/CMakeLists.txt
+++ b/tests/features/pll/CMakeLists.txt
@@ -16,3 +16,10 @@ add_generic_test(
     board_list basys3
     sources pll_buf_basys3.v plle2_test.v
 )
+
+# FIXME: Timeout on analytical placer
+add_generic_test(
+    name plle4_adv
+    board_list zcu104
+    sources util.v plle4_adv.v
+)

--- a/tests/features/pll/plle4_adv.v
+++ b/tests/features/pll/plle4_adv.v
@@ -15,7 +15,7 @@ module top (
     IBUFDS ibuf_ds (.I(clk_p), .IB(clk_n), .O(clk));
 
     wire locked;
-    wire clk0, clk1;
+    wire clk0d, clk1d, clk0, clk1;
     wire clkfb;
 
     PLLE4_ADV #(
@@ -35,8 +35,8 @@ module top (
         .CLKIN         (clk),
         .RST           (rst),
         .LOCKED        (locked),
-        .CLKOUT0       (clk0),
-        .CLKOUT1       (clk1),
+        .CLKOUT0       (clk0d),
+        .CLKOUT1       (clk1d),
         .CLKOUTPHYEN   (1'b0),
         .PWRDWN        (1'b0),
         .DADDR         (7'b0),
@@ -44,6 +44,9 @@ module top (
         .CLKFBIN       (clkfb),
         .CLKFBOUT      (clkfb)
     );
+    
+    BUFGCE b0 (.CE(1'b1), .I(clk0d), .O(clk0));
+    BUFGCE b1 (.CE(1'b1), .I(clk1d), .O(clk1));
 
     wire rst0, rst1;
     sig_fifo1 fifo_rst0(clk, clk0, rst, rst0);

--- a/tests/features/pll/plle4_adv.v
+++ b/tests/features/pll/plle4_adv.v
@@ -1,3 +1,11 @@
+// Copyright (C) 2021  The Symbiflow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
 module top (
     input wire clk_p, clk_n,
     input wire rst,

--- a/tests/features/pll/plle4_adv.v
+++ b/tests/features/pll/plle4_adv.v
@@ -1,0 +1,54 @@
+module top (
+    input wire clk_p, clk_n,
+    input wire rst,
+    output wire [7:0] leds
+);
+    wire clk;
+    IBUFDS ibuf_ds (.I(clk_p), .IB(clk_n), .O(clk));
+
+    wire locked;
+    wire clk0, clk1;
+    wire clkfb;
+
+    PLLE4_ADV #(
+        .CLKFBOUT_MULT        (8),    // 1GHz
+        .CLKFBOUT_PHASE       (0.000),
+        .CLKIN_PERIOD         (8.0),  // 125MHz
+
+        /* CLK0 */
+        .CLKOUT0_DIVIDE       (20),  // 50MHz
+        .CLKOUT0_DUTY_CYCLE   (0.500),
+        .CLKOUT0_PHASE        (0.000),
+        /* CLK1 */
+        .CLKOUT1_DIVIDE       (5),  // 200MHz
+        .CLKOUT1_DUTY_CYCLE   (0.500),
+        .CLKOUT1_PHASE        (0.000)
+    ) pll (
+        .CLKIN         (clk),
+        .RST           (rst),
+        .LOCKED        (locked),
+        .CLKOUT0       (clk0),
+        .CLKOUT1       (clk1),
+        .CLKOUTPHYEN   (1'b0),
+        .PWRDWN        (1'b0),
+        .DADDR         (7'b0),
+        .DEN           (1'b0),
+        .CLKFBIN       (clkfb),
+        .CLKFBOUT      (clkfb)
+    );
+
+    wire rst0, rst1;
+    sig_fifo1 fifo_rst0(clk, clk0, rst, rst0);
+    sig_fifo1 fifo_rst1(clk, clk1, rst, rst1);
+
+    wire slow_cnt0, slow_cnt1;
+    counter #(.WIDTH(24)) slow0 (clk0, rst0, slow_cnt0);
+    counter #(.WIDTH(24)) slow1 (clk1, rst1, slow_cnt1);
+
+    wire sclk0, sclk1;
+    assign sclk0 = (slow_cnt0 == 0) | rst0;
+    assign sclk1 = (slow_cnt1 == 0) | rst1;
+
+    counter #(.WIDTH(4)) out0 (sclk0, rst0, leds[3:0]);
+    counter #(.WIDTH(4)) out1 (sclk1, rst1, leds[7:4]);
+endmodule

--- a/tests/features/pll/util.v
+++ b/tests/features/pll/util.v
@@ -1,0 +1,39 @@
+// Copyright (C) 2021  The Symbiflow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+module counter (
+    input wire clk,
+    input wire rst,
+    output reg [(WIDTH-1):0] cnt
+);
+    parameter WIDTH = 32;
+
+    always @(posedge clk) begin
+        if (rst)
+            cnt <= 0;
+        else
+            cnt <= cnt + 1;
+    end
+endmodule
+
+module sig_fifo1 (
+    input wire iclk,
+    input wire oclk,
+    input wire isig,
+    output reg osig
+);
+    reg b = 0;
+
+    always @(posedge iclk, posedge oclk) begin
+        if (iclk)
+            b <= isig;
+        else if (oclk)
+            osig <= b;
+    end
+        
+endmodule

--- a/tests/features/pll/zcu104.xdc
+++ b/tests/features/pll/zcu104.xdc
@@ -1,0 +1,19 @@
+# ZCU-104 board
+
+# Clock
+set_property PACKAGE_PIN H11 [get_ports clk_p]
+set_property PACKAGE_PIN G11 [get_ports clk_n]
+
+set_property IOSTANDARD LVDS [get_ports clk_p]
+set_property IOSTANDARD LVDS [get_ports clk_n]
+
+# PMOD GPIO
+set_property PACKAGE_PIN  G8 [get_ports leds[0]]
+set_property PACKAGE_PIN  H8 [get_ports leds[1]]
+set_property PACKAGE_PIN  G7 [get_ports leds[2]]
+set_property PACKAGE_PIN  H7 [get_ports leds[3]]
+set_property PACKAGE_PIN  G6 [get_ports leds[4]]
+set_property PACKAGE_PIN  H6 [get_ports leds[5]]
+set_property PACKAGE_PIN  J6 [get_ports leds[6]]
+set_property PACKAGE_PIN  J7 [get_ports leds[7]]
+set_property PACKAGE_PIN  J9 [get_ports rst]

--- a/tests/features/serdes/CMakeLists.txt
+++ b/tests/features/serdes/CMakeLists.txt
@@ -3,3 +3,11 @@ add_generic_test(
     board_list basys3
     sources serdes.v serdes_test.v
 )
+
+# FIXME: Timeout on analytical placer
+add_generic_test(
+    name iserdese3
+    board_list zcu104
+    sources iserdese3.v
+    constr_prefix iserdese3
+)

--- a/tests/features/serdes/iserdese3-zcu104.xdc
+++ b/tests/features/serdes/iserdese3-zcu104.xdc
@@ -1,0 +1,24 @@
+# ZCU-104 board
+
+# Clock
+set_property PACKAGE_PIN H11 [get_ports clk_p]
+set_property PACKAGE_PIN G11 [get_ports clk_n]
+
+set_property IOSTANDARD LVDS [get_ports clk_p]
+set_property IOSTANDARD LVDS [get_ports clk_n]
+
+# PMOD GPIO
+set_property PACKAGE_PIN  H8 [get_ports rst]
+set_property PACKAGE_PIN  G7 [get_ports outputs[0]]
+set_property PACKAGE_PIN  H7 [get_ports outputs[1]]
+set_property PACKAGE_PIN  G6 [get_ports outputs[2]]
+set_property PACKAGE_PIN  H6 [get_ports outputs[3]]
+set_property PACKAGE_PIN  J6 [get_ports outputs[4]]
+set_property PACKAGE_PIN  J7 [get_ports outputs[5]]
+set_property PACKAGE_PIN  J9 [get_ports outputs[6]]
+set_property PACKAGE_PIN  K9 [get_ports outputs[7]]
+set_property PACKAGE_PIN  K8 [get_ports in]
+set_property PACKAGE_PIN  L8 [get_ports rd_en]
+set_property PACKAGE_PIN  B3 [get_ports t_dat]
+
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk_IBUF_inst/0]

--- a/tests/features/serdes/iserdese3.v
+++ b/tests/features/serdes/iserdese3.v
@@ -1,0 +1,60 @@
+`timescale 1ns / 1ps
+
+module clkdivider (
+    input wire clk,
+    input wire rst,
+    output wire clk_out
+);
+    parameter DOUBLE_DIVISOR = 1;
+
+    reg counter = 4'b0;
+
+    always @(posedge clk) begin
+        if (rst)
+            counter <= 4'b0;
+        else begin
+            if (counter == DOUBLE_DIVISOR)
+                counter <= 4'b0;
+            else
+                counter <= 4'b1;
+        end
+    end
+
+    assign clk_out = counter < (DOUBLE_DIVISOR / 2);
+endmodule
+
+
+module top (
+    input wire clk_p,
+    input wire clk_n,
+    input wire rst,
+    input wire rd_en,
+    input wire in,
+    output wire [7:0] outputs,
+    output wire t_dat
+);
+    wire clk;
+    wire clk_div;
+    
+    IBUFDS ibuf_ds (.I(clk_p), .IB(clk_n), .O(clk));
+    
+    clkdivider #(.DOUBLE_DIVISOR(4)) clkdiv1 (
+        .clk       (clk),
+        .rst       (rst),
+        .clk_out   (clk_div)
+    );
+
+    ISERDESE3 #(
+        .DATA_WIDTH   (8),
+        .SIM_DEVICE   ("ULTRASCALE_PLUS")
+    ) deserializer (
+        .CLK          (clk),
+        .CLK_B        (~clk),
+        .RST          (rst),
+        .CLKDIV       (clk_div),
+        .D            (in),
+        .FIFO_RD_EN   (rd_en),
+        .Q            (outputs)
+    );
+    
+endmodule

--- a/tests/features/serdes/iserdese3.v
+++ b/tests/features/serdes/iserdese3.v
@@ -1,3 +1,11 @@
+// Copyright (C) 2021  The Symbiflow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
 `timescale 1ns / 1ps
 
 module clkdivider (


### PR DESCRIPTION
### This PR adds the following **FAILING(?)** tests for Ultrascale+ family (ZCU104):

**DRAM**:
* 1_256x1s

**PLL**:
* PLL4_ADV

**SERDES**:
* ISERDESE3

These tests hang on analytical placer causing the build to never succeed.