### PR TITLE
Feature tests for Ultrascale+ (failing on not enough cells)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
     - litex-hub::capnproto-java=0.1.5_0012_g44a8c1e=20201104_165332
     - litex-hub::gcc-riscv64-elf-newlib=9.2.0=20201119_154229
     - litex-hub::iverilog=0_8_5850_g540555fc=20210730_085634
-    - litex-hub::nextpnr-fpga_interchange=0.1_103_g74c99f91=20220202_022309_py37
+    - litex-hub::nextpnr-fpga_interchange=0.2_33_g81e97086=20220302_164843_py37
     - litex-hub::prjoxide=v0.0_398_g711770c=20210730_085634
     - litex-hub::prjxray-db=0.0_257_g0a0adde=20220202_022309
     - litex-hub::prjxray-tools=0.1_2942_g5349556b=20220202_022309

--- a/tests/features/ram_36bit/CMakeLists.txt
+++ b/tests/features/ram_36bit/CMakeLists.txt
@@ -11,3 +11,11 @@ add_xc7_validation_test(
     testbench ram_36bit_tb.v
     disable_vivado_test
 )
+
+add_generic_test(
+    name ram_36bit
+    board_list zcu104
+    sources ram_36bit.v ram_36bit_zcu104.v
+    top top_zcu104
+    failure_allowed
+)

--- a/tests/features/ram_36bit/ram_36bit_zcu104.v
+++ b/tests/features/ram_36bit/ram_36bit_zcu104.v
@@ -1,0 +1,40 @@
+// Copyright (C) 2022  The F4PGA Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+module top_zcu104 (
+    input wire clk_p,
+    input wire clk_n,
+    output wire [15:0] led,
+    input wire [15:0] sw,
+    output wire tx,
+    input wire rx,
+    input wire butu,
+    input wire butd,
+    input wire butl,
+    input wire butr,
+    input wire butc
+);
+
+    // The ZCU104 CLK comes from a differential pair
+    wire clk;
+    IBUFDS ibuf_ds (.I(clk_p), .IB(clk_n), .O(clk));
+
+    top top_ (
+        .led(led),
+        .sw(sw),
+        .tx(tx),
+        .rx(rx),
+        .butu(butu),
+        .butd(butd),
+        .butl(butl),
+        .butr(butr),
+        .butc(butc),
+        .clk(clk)
+    );
+endmodule
+

--- a/tests/features/ram_36bit/zcu104.xdc
+++ b/tests/features/ram_36bit/zcu104.xdc
@@ -1,0 +1,103 @@
+# ZCU-104 board
+
+# Clock
+set_property PACKAGE_PIN H11 [get_ports clk_p]
+set_property PACKAGE_PIN G11 [get_ports clk_n]
+
+set_property IOSTANDARD LVDS [get_ports clk_p]
+set_property IOSTANDARD LVDS [get_ports clk_n]
+
+# PMOD GPIO
+set_property PACKAGE_PIN  G8 [get_ports led[0]]
+set_property PACKAGE_PIN  H8 [get_ports led[1]]
+set_property PACKAGE_PIN  G7 [get_ports led[2]]
+set_property PACKAGE_PIN  H7 [get_ports led[3]]
+set_property PACKAGE_PIN  G6 [get_ports led[4]]
+set_property PACKAGE_PIN  H6 [get_ports led[5]]
+set_property PACKAGE_PIN  J6 [get_ports led[6]]
+set_property PACKAGE_PIN  J7 [get_ports led[7]]
+set_property PACKAGE_PIN  J9 [get_ports led[8]]
+set_property PACKAGE_PIN  K9 [get_ports led[9]]
+set_property PACKAGE_PIN  K8 [get_ports led[10]]
+set_property PACKAGE_PIN  L8 [get_ports led[11]]
+set_property PACKAGE_PIN L10 [get_ports led[12]]
+set_property PACKAGE_PIN M10 [get_ports led[13]]
+set_property PACKAGE_PIN  M8 [get_ports led[14]]
+set_property PACKAGE_PIN  M9 [get_ports led[15]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[3]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[4]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[5]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[6]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[7]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[8]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[9]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[10]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[11]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[12]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[13]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[14]]
+set_property IOSTANDARD LVCMOS33 [get_ports led[15]]
+
+# Pushbuttons
+set_property PACKAGE_PIN B4 [get_ports sw[0]]
+set_property PACKAGE_PIN C4 [get_ports sw[1]]
+set_property PACKAGE_PIN B3 [get_ports sw[2]]
+set_property PACKAGE_PIN C3 [get_ports sw[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports sw[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[3]]
+
+# DIP SW
+
+set_property PACKAGE_PIN E4 [get_ports sw[4]]
+set_property PACKAGE_PIN D4 [get_ports sw[5]]
+set_property PACKAGE_PIN F5 [get_ports sw[6]]
+set_property PACKAGE_PIN F4 [get_ports sw[7]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports sw[4]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[5]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[6]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[7]]
+
+# Abusing HDMI pins
+
+set_property PACKAGE_PIN  B1 [get_ports sw[8]]
+set_property PACKAGE_PIN  C1 [get_ports sw[9]]
+set_property PACKAGE_PIN  A2 [get_ports sw[10]]
+set_property PACKAGE_PIN  A3 [get_ports sw[11]]
+set_property PACKAGE_PIN  E3 [get_ports sw[12]]
+set_property PACKAGE_PIN N11 [get_ports sw[13]]
+set_property PACKAGE_PIN M12 [get_ports sw[14]]
+set_property PACKAGE_PIN  F6 [get_ports sw[15]]
+set_property PACKAGE_PIN  E5 [get_ports rx]
+set_property PACKAGE_PIN  D1 [get_ports tx]
+set_property PACKAGE_PIN  E1 [get_ports butu]
+set_property PACKAGE_PIN  D2 [get_ports butd]
+set_property PACKAGE_PIN  E2 [get_ports butl]
+
+set_property IOSTANDARD LVCMOS33 [get_ports sw[8]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[9]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[10]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[11]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[12]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[13]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[14]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[15]]
+set_property IOSTANDARD LVCMOS33 [get_ports rx]
+set_property IOSTANDARD LVCMOS33 [get_ports tx]
+set_property IOSTANDARD LVCMOS33 [get_ports butu]
+set_property IOSTANDARD LVCMOS33 [get_ports butd]
+set_property IOSTANDARD LVCMOS33 [get_ports butl]
+
+# LEDs
+set_property PACKAGE_PIN D5 [get_ports butr]
+set_property PACKAGE_PIN D6 [get_ports butc]
+
+set_property IOSTANDARD LVCMOS33 [get_ports butr]
+set_property IOSTANDARD LVCMOS33 [get_ports butc]


### PR DESCRIPTION
### This PR adds the following **FAILING** tests for Ultrascale+ family (ZCU104):

**BRAM (with differential clock)**:
* ram_36bit

nextpnr complains about not enough LUT cells being available. Depite that it does seem to infer the usage of BRAM as it's reported that one BRAM cell was used.