### PR TITLE
cmake: add target to run all dcp generation for xilinx archs

### DIFF
--- a/devices/chipdb_xilinx.cmake
+++ b/devices/chipdb_xilinx.cmake
@@ -159,6 +159,8 @@ function(generate_xc7_device_db)
     if(DEFINED device_target)
         set(${device_target} timing-${device}-device PARENT_SCOPE)
     endif()
+    
+    add_custom_target(all-${device}-dcp-bit)
 endfunction()
 
 function(generate_xcup_device_db)

--- a/tests/arch_tests.cmake
+++ b/tests/arch_tests.cmake
@@ -139,6 +139,7 @@ function(add_xc7_test)
       add_custom_target(${arch}-${test_name}-dcp-bit DEPENDS ${dcp_bit})
       add_dependencies(all-vendor-bit-tests ${arch}-${test_name}-dcp-bit)
       add_dependencies(all-${device}-vendor-bit-tests ${arch}-${test_name}-dcp-bit)
+      add_dependencies(all-${device}-dcp-bit ${arch}-${test_name}-dcp-bit)
 
       set(dcp_fasm ${output_dir}/${name}.dcp.bit.fasm)
       add_custom_command(
@@ -396,6 +397,7 @@ function(add_xcup_test)
         add_custom_target(${arch}-${test_name}-dcp-bit DEPENDS ${dcp_bit})
         add_dependencies(all-vendor-bit-tests ${arch}-${test_name}-dcp-bit)
         add_dependencies(all-${device}-vendor-bit-tests ${arch}-${test_name}-dcp-bit)
+        add_dependencies(all-${device}-dcp-bit ${arch}-${test_name}-dcp-bit)
     endif()
 
 endfunction()


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>