### PR TITLE
Add UHDM/SystemVerilog support and test

### DIFF
--- a/conda_lock.yml
+++ b/conda_lock.yml
@@ -54,6 +54,7 @@ dependencies:
   - wheel=0.37.1=pyhd3eb1b0_0
   - xz=5.2.5=h7f8727e_1
   - yosys=0.17_7_g990c9b8e1=20220512_085338_py37
+  - symbiflow-yosys-plugins=1.0.0_7_855_gd64a754=20220330_123635
   - zlib=1.2.12=h7f8727e_2
   - zstd=1.5.2=ha4553b6_0
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
     - litex-hub::prjxray-tools
     - litex-hub::vtr-optimized
     - litex-hub::yosys
+    - litex-hub::symbiflow-yosys-plugins=1.0.0_7_855_gd64a754=20220330_123635
     - swig
     - packaging=21.3
     - pip=21.1.3

--- a/tests/common/synth_xc7.tcl
+++ b/tests/common/synth_xc7.tcl
@@ -1,7 +1,18 @@
 yosys -import
 
+set use_uhdm $::env(USE_UHDM)
+
+if { $use_uhdm } {
+    plugin -i systemverilog
+    yosys -import
+}
+
 foreach src $::env(SOURCES) {
-    read_verilog $src
+    if { $use_uhdm } {
+        read_systemverilog $src
+    } else {
+        read_verilog $src
+    }
 }
 
 techmap -map $::env(LIB_DIR)/retarget_xc7.v

--- a/tests/designs/CMakeLists.txt
+++ b/tests/designs/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(counter)
+add_subdirectory(counter_sv)
 add_subdirectory(litex_base)
 add_subdirectory(litex_linux)
 add_subdirectory(murax)

--- a/tests/designs/counter_sv/CMakeLists.txt
+++ b/tests/designs/counter_sv/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_generic_test(
+    name counter_sv
+    board_list basys3 arty35t arty100t arty_s7_25 arty_s7_50 xc7k70t_board xc7k160t_board xc7k480t_board xc7vx980t_board lifcl40evn
+    sources counter.sv
+    uhdm
+)
+
+add_generic_test(
+    name counter_sv
+    board_list zcu104
+    sources counter_diff_clk.sv
+    uhdm
+)

--- a/tests/designs/counter_sv/arty100t.xdc
+++ b/tests/designs/counter_sv/arty100t.xdc
@@ -1,0 +1,14 @@
+## arty-100t board
+set_property PACKAGE_PIN E3  [get_ports clk]
+set_property PACKAGE_PIN D9  [get_ports rst]
+set_property PACKAGE_PIN H5  [get_ports io_led[0]]
+set_property PACKAGE_PIN J5  [get_ports io_led[1]]
+set_property PACKAGE_PIN T9  [get_ports io_led[2]]
+set_property PACKAGE_PIN T10 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/arty35t.xdc
+++ b/tests/designs/counter_sv/arty35t.xdc
@@ -1,0 +1,14 @@
+## arty-35t board
+set_property PACKAGE_PIN E3  [get_ports clk]
+set_property PACKAGE_PIN D9  [get_ports rst]
+set_property PACKAGE_PIN H5  [get_ports io_led[0]]
+set_property PACKAGE_PIN J5  [get_ports io_led[1]]
+set_property PACKAGE_PIN T9  [get_ports io_led[2]]
+set_property PACKAGE_PIN T10 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/arty_s7_25.xdc
+++ b/tests/designs/counter_sv/arty_s7_25.xdc
@@ -1,0 +1,14 @@
+## arty-s7-25 board
+set_property PACKAGE_PIN R2  [get_ports clk]
+set_property PACKAGE_PIN G15 [get_ports rst]
+set_property PACKAGE_PIN E18 [get_ports io_led[0]]
+set_property PACKAGE_PIN F13 [get_ports io_led[1]]
+set_property PACKAGE_PIN E13 [get_ports io_led[2]]
+set_property PACKAGE_PIN H15 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/arty_s7_50.xdc
+++ b/tests/designs/counter_sv/arty_s7_50.xdc
@@ -1,0 +1,14 @@
+## arty-s7-50 board
+set_property PACKAGE_PIN R2  [get_ports clk]
+set_property PACKAGE_PIN G15 [get_ports rst]
+set_property PACKAGE_PIN E18 [get_ports io_led[0]]
+set_property PACKAGE_PIN F13 [get_ports io_led[1]]
+set_property PACKAGE_PIN E13 [get_ports io_led[2]]
+set_property PACKAGE_PIN H15 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/basys3.xdc
+++ b/tests/designs/counter_sv/basys3.xdc
@@ -1,0 +1,14 @@
+## basys3 breakout board
+set_property PACKAGE_PIN W5 [get_ports clk]
+set_property PACKAGE_PIN V17 [get_ports rst]
+set_property PACKAGE_PIN U16 [get_ports io_led[0]]
+set_property PACKAGE_PIN E19 [get_ports io_led[1]]
+set_property PACKAGE_PIN U19 [get_ports io_led[2]]
+set_property PACKAGE_PIN V19 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/counter.sv
+++ b/tests/designs/counter_sv/counter.sv
@@ -1,0 +1,27 @@
+// Copyright (C) 2021  The Symbiflow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+module top (
+    input  logic clk,
+    input  logic rst,
+    output logic [3:0] io_led
+);
+
+logic [31:0] counter = 32'b0;
+
+assign io_led = counter[5:2];
+
+always_ff @(posedge clk)
+begin
+    if(rst)
+        counter <= 32'b0;
+    else
+        counter <= counter + 1;
+end
+
+endmodule

--- a/tests/designs/counter_sv/counter_diff_clk.sv
+++ b/tests/designs/counter_sv/counter_diff_clk.sv
@@ -1,0 +1,31 @@
+// Copyright (C) 2021  The Symbiflow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+module top (
+    input  logic clk_p, clk_n,
+    input  logic rst,
+    output logic [3:0] io_led
+);
+
+wire clk;
+
+IBUFDS ibuf_ds (.I(clk_p), .IB(clk_n), .O(clk));
+
+logic [31:0] counter = 32'b0;
+
+assign io_led = counter[25:22];
+
+always @(posedge clk)
+begin
+    if(rst)
+        counter <= 32'b0;
+    else
+        counter <= counter + 1;
+end
+
+endmodule

--- a/tests/designs/counter_sv/lifcl40evn.xdc
+++ b/tests/designs/counter_sv/lifcl40evn.xdc
@@ -1,0 +1,13 @@
+set_property PACKAGE_PIN L13 [get_ports clk]
+set_property PACKAGE_PIN G19 [get_ports rst]
+set_property PACKAGE_PIN E17 [get_ports io_led[0]]
+set_property PACKAGE_PIN F13 [get_ports io_led[1]]
+set_property PACKAGE_PIN G13 [get_ports io_led[2]]
+set_property PACKAGE_PIN F14 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/xc7k160t_board.xdc
+++ b/tests/designs/counter_sv/xc7k160t_board.xdc
@@ -1,0 +1,14 @@
+# Pinout for FFG676 package
+set_property PACKAGE_PIN C12 [get_ports clk]
+set_property PACKAGE_PIN C21 [get_ports rst]
+set_property PACKAGE_PIN D21 [get_ports io_led[0]]
+set_property PACKAGE_PIN B20 [get_ports io_led[1]]
+set_property PACKAGE_PIN B21 [get_ports io_led[2]]
+set_property PACKAGE_PIN C22 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/xc7k480t_board.xdc
+++ b/tests/designs/counter_sv/xc7k480t_board.xdc
@@ -1,0 +1,14 @@
+# Fake pinout for FFG901 package
+set_property PACKAGE_PIN A14 [get_ports clk]
+set_property PACKAGE_PIN A15 [get_ports rst]
+set_property PACKAGE_PIN A16 [get_ports io_led[0]]
+set_property PACKAGE_PIN A17 [get_ports io_led[1]]
+set_property PACKAGE_PIN B14 [get_ports io_led[2]]
+set_property PACKAGE_PIN B15 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/xc7k70t_board.xdc
+++ b/tests/designs/counter_sv/xc7k70t_board.xdc
@@ -1,0 +1,14 @@
+# Pinout for FBG484 package
+set_property PACKAGE_PIN L19 [get_ports clk]
+set_property PACKAGE_PIN E8 [get_ports rst]
+set_property PACKAGE_PIN F8 [get_ports io_led[0]]
+set_property PACKAGE_PIN C8 [get_ports io_led[1]]
+set_property PACKAGE_PIN A8 [get_ports io_led[2]]
+set_property PACKAGE_PIN D9 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/xc7vx980t_board.xdc
+++ b/tests/designs/counter_sv/xc7vx980t_board.xdc
@@ -1,0 +1,14 @@
+# Fake pinout for FFG1926 package
+set_property PACKAGE_PIN A13 [get_ports clk]
+set_property PACKAGE_PIN A14 [get_ports rst]
+set_property PACKAGE_PIN A15 [get_ports io_led[0]]
+set_property PACKAGE_PIN A16 [get_ports io_led[1]]
+set_property PACKAGE_PIN B12 [get_ports io_led[2]]
+set_property PACKAGE_PIN B13 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/designs/counter_sv/zcu104.xdc
+++ b/tests/designs/counter_sv/zcu104.xdc
@@ -1,0 +1,16 @@
+## basys3 breakout board
+set_property PACKAGE_PIN F23 [get_ports clk_p]
+set_property PACKAGE_PIN E23 [get_ports clk_n]
+
+set_property PACKAGE_PIN M11 [get_ports rst]
+set_property PACKAGE_PIN D5 [get_ports io_led[0]]
+set_property PACKAGE_PIN D6 [get_ports io_led[1]]
+set_property PACKAGE_PIN A5 [get_ports io_led[2]]
+set_property PACKAGE_PIN B5 [get_ports io_led[3]]
+
+set_property IOSTANDARD LVDS [get_ports clk_p]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[1]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[2]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[3]]

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -36,7 +36,7 @@ function(add_generic_test)
     #   - <arch>-<name>-<board>-phys     : physical interchange netlist
     #   - <arch>-<name>-<board>-fasm     : fasm file
 
-    set(options failure_allowed)
+    set(options failure_allowed uhdm)
     set(oneValueArgs name tcl top testbench constr_prefix generated_xdc)
     set(multiValueArgs board_list sources absolute_sources built_sources)
 
@@ -55,6 +55,7 @@ function(add_generic_test)
     set(constr_prefix ${add_generic_test_constr_prefix})
     set(generated_xdc ${add_generic_test_generated_xdc})
     set(failure_allowed ${add_generic_test_failure_allowed})
+    set(uhdm ${add_generic_test_uhdm})
 
     set(sources)
     foreach(source ${add_generic_test_sources})
@@ -123,6 +124,13 @@ function(add_generic_test)
         set(synth_json ${output_dir}/${name}.json)
         set(synth_log ${output_dir}/${name}.synth.log)
         set(synth_verilog ${output_dir}/${name}.synth.v)
+
+        if(uhdm)
+            set(use_uhdm TRUE)
+        else()
+            set(use_uhdm FALSE)
+        endif()
+
         add_custom_command(
             OUTPUT ${synth_json}
             COMMAND ${CMAKE_COMMAND} -E env
@@ -130,6 +138,7 @@ function(add_generic_test)
                 OUT_JSON=${synth_json}
                 OUT_VERILOG=${synth_verilog}
                 LIB_DIR=${lib_dir}
+                USE_UHDM=${use_uhdm}
                 ${quiet_cmd}
                 ${YOSYS} -c ${synth_tcl} -l ${synth_log}
             DEPENDS


### PR DESCRIPTION
Adds support for designs that reuire UHDM/SystemVerilog yosys plugin.

The downside is that there's no support for testbenches as SystemVerilog support in Icarus Verilog is almost non-existent.