### PR TITLE
Add building data for NISP

### DIFF
--- a/.github/scripts/centos-setup.sh
+++ b/.github/scripts/centos-setup.sh
@@ -28,6 +28,9 @@ make install
 popd
 ln -sf /usr/local/bin/make /usr/bin/make
 
+# Copy java.capnp needed by NISP
+cp ./third_party/nextpnr-fpga-interchange-site-preprocessor/third_party/capnproto-java/compiler/src/main/schema/capnp/java.capnp /usr/include/capnp/java.capnp
+
 # Check versions
 make --version
 cmake --version

--- a/.github/scripts/pack-interchange-data.sh
+++ b/.github/scripts/pack-interchange-data.sh
@@ -37,6 +37,7 @@ LINK_PREFIX=$3
 INSTALL_DIR="$(pwd)/install"
 
 # Prepare environment
+source "$HOME/.cargo/env"
 make env
 source env/conda/bin/activate fpga-interchange
 

--- a/.github/scripts/ubuntu-setup.sh
+++ b/.github/scripts/ubuntu-setup.sh
@@ -10,8 +10,11 @@
 set -e
 apt-get -qqy update
 apt-get -qqy install build-essential git make locales libtinfo-dev \
-  cmake python3 wget unzip curl openjdk-11-jdk-headless capnproto
+  cmake python3 wget unzip curl openjdk-11-jdk-headless capnproto libcapnp-dev
 dpkg-reconfigure locales
+
+# Copy java.capnp needed by NISP
+cp ./third_party/nextpnr-fpga-interchange-site-preprocessor/third_party/capnproto-java/compiler/src/main/schema/capnp/java.capnp /usr/include/capnp/java.capnp
 
 # Vivado is erroring out due to a missing library in CI.
 # https://support.xilinx.com/s/article/76585?language=en_US

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,17 @@ jobs:
       run: |
         .github/scripts/ubuntu-setup.sh
 
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
     - name: Create environment
-      run: make env
+      run: |
+        make env
 
     - name: Build CMake
       run: |
+        source "$HOME/.cargo/env"
         make build
         make update
 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
 
     - name: Install prerequisites
       run: |
@@ -47,6 +49,10 @@ jobs:
         apt update -qqy
         apt install -qqy gnupg2 google-cloud-cli
 
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
     - name: Save timestamp
       id: timestamp
       run: |
@@ -54,6 +60,7 @@ jobs:
 
     - name: Generate interchange data
       run: |
+        source "$HOME/.cargo/env"
         .github/scripts/pack-interchange-data.sh \
           interchange_tarballs \
           links \

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -60,7 +60,6 @@ jobs:
 
     - name: Generate interchange data
       run: |
-        source "$HOME/.cargo/env"
         .github/scripts/pack-interchange-data.sh \
           interchange_tarballs \
           links \

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "third_party/litex-boards"]
 	path = third_party/litex-boards
 	url = https://github.com/litex-hub/litex-boards.git
+[submodule "third_party/nextpnr-fpga-interchange-site-preprocessor"]
+	path = third_party/nextpnr-fpga-interchange-site-preprocessor
+	url = https://github.com/antmicro/nextpnr-fpga-interchange-site-preprocessor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,16 @@ set_program(vvp)
 set_program(xcfasm)
 set_program(yosys)
 
+if(DEFINED ENV{"NISP"})
+    set(NISP_PATH $ENV{"NISP"})
+else()
+    get_filename_component(NISP_PATH "third_party/nextpnr-fpga-interchange-site-preprocessor/nisp" ABSOLUTE)
+endif()
+
+set_target_properties(
+    programs PROPERTIES NISP ${NISP_PATH}
+)
+
 include(boards/boards.cmake)
 include(devices/chipdb.cmake)
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ nisp: ${NISP_PATH}/nisp
 .PHONY: clean-nisp
 clean-nisp:
 	@rm -rf ${NISP_PATH}/target
-	@unlink ${NISP_PATH}/nisp || true
+	-@unlink ${NISP_PATH}/nisp
 
 .PHONY: build
 build: ${NISP_PATH}/nisp


### PR DESCRIPTION
This PR adds Nextpnr Interchange Site Preprocessor (NISP) utility (https://github.com/antmicro/nextpnr-fpga-interchange-site-preprocessor) as a submodule and uses it to generate supplementary data to FPGA interchange device resources.

Ultimately the data will be included in BBA and BIN files for nextpnr but for now it is stored in separate JSON files.